### PR TITLE
Fixed wrong content length when request body contains non-ascii characters

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -17,7 +17,7 @@ function request(options) {
         options.method = options.method || "POST";
         options.host = options.host || "localhost";
         options.headers = {
-            "Content-Length": options.body.length,
+            "Content-Length": Buffer.byteLength(options.body),
             "Content-Type":   "application/json"
         };
 


### PR DESCRIPTION
Content-Length is bytes and not necessarily string length. Using Buffer.byteLength(string) will always be correct. Ref stackoveflow question http://stackoverflow.com/questions/18692580/node-js-post-causes-error-socket-hang-up-code-econnreset
