### PR TITLE
Remove heartbeat for synchronous messages to phantom

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -65,7 +65,7 @@ Page.prototype.run = function (args, fn) {
             src: serializeFn(fn, args),
             pageId: this._id
         }
-    });
+    }, args.length === fn.length);
 };
 
 /**

--- a/lib/Phantom.js
+++ b/lib/Phantom.js
@@ -98,7 +98,7 @@ Phantom.prototype.run = function (args, fn) {
         data: {
             src: serializeFn(fn, args)
         }
-    });
+    }, args.length === fn.length);
 };
 
 /**
@@ -159,7 +159,7 @@ Phantom.prototype.dispose = function () {
  * @returns {Promise}
  * @private
  */
-Phantom.prototype._send = function (message) {
+Phantom.prototype._send = function (message, fnIsSync) {
     var self = this;
 
     message.from = new Error().stack
@@ -173,7 +173,7 @@ Phantom.prototype._send = function (message) {
             resolve: resolve,
             reject: reject
         };
-        if (self._pending === 0) {
+        if (self._pending === 0 && !fnIsSync) {
             self._heartbeatIntervalId = setInterval(self._sendHeartbeat, heartbeatInterval);
         }
         self._pending++;


### PR DESCRIPTION
This fixes and issue with delays between synchronous calls to phantom using "run" function.
In old version when synchronous function was called heartbeat was sent as well cluttering phantom stdin.
Between "_send" and "_receive" actions node was sending heartbeat  messages which had to be processed by the phantom - even though code run on phantom was synchronous. 
