### PR TITLE
Can now pass CLI style JSON props i.e. '--remote-debugger-port':8888

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -27,6 +27,7 @@ var initialMessage = "message to node: hi";
  */
 function spawn(phantomJsConfig) {
     var configPath;
+    var cliStyleOpts = [];
     var stdout;
     var stderr;
     var child;
@@ -45,6 +46,15 @@ function spawn(phantomJsConfig) {
     return open(null)
         .then(function writeConfig(info) {
             configPath = info.path;
+
+            //Pass config items in CLI style (--some-config) separately
+            //to avoid Phantom's JSON config bugs
+            for (var i in phantomJsConfig) {
+              if (i[0] === '-') {
+                cliStyleOpts.push(i + '=' + phantomJsConfig[i]);
+                delete phantomJsConfig[i];
+              }
+            }
 
             return writeFile(info.path, JSON.stringify(phantomJsConfig))
                 .then(function () {
@@ -79,11 +89,21 @@ function spawn(phantomJsConfig) {
                     reject(new Error(message));
                 }
 
-                child = childProcess.spawn(phantomjs.path, [
-                    "--config=" + configPath,
-                    startScript,
-                    configPath
-                ]);
+                var spawnOptions = [
+                  "--config=" + configPath,
+                  startScript,
+                  configPath
+                ];
+
+                //Add in CLI style options
+                /**/
+                if (cliStyleOpts.length > 0) {
+                  while (cliStyleOpts.length > 0) {
+                    spawnOptions.splice(1, 0, cliStyleOpts.pop());
+                  }
+                }
+
+                child = childProcess.spawn(phantomjs.path, spawnOptions);
 
                 prepareChildProcess(child);
 


### PR DESCRIPTION
Can now pass CLI style JSON props i.e. '--remote-debugger-port':8888 to phridge.spawn(). This addresses unfixed phantomjs bugs.

See https://github.com/peerigon/phridge/issues/31