### PR TITLE
handle killed phantomjs process gracefully

### DIFF
--- a/lib/Phantom.js
+++ b/lib/Phantom.js
@@ -72,6 +72,8 @@ Phantom.prototype.constructor = function (childProcess) {
     childProcess.phridge.on("data", this._receive);
 
     childProcess.on("exit", function onExit() {
+        clearTimeout(self._pingTimeoutId);
+        self.rejectPendingDeferreds();
         instances.splice(instances.indexOf(self), 1);
     });
 };
@@ -143,11 +145,8 @@ Phantom.prototype.dispose = function () {
         }
 
         self.childProcess.on("exit", resolve);
-
         self.run(phantomMethods.exitPhantom).catch(reject);
-
         self.childProcess = null;
-        clearTimeout(self._pingTimeoutId);
     });
 };
 
@@ -247,6 +246,15 @@ Phantom.prototype._schedulePing = function () {
     }
     this._pingTimeoutId = setTimeout(write, pingInterval, this.childProcess, { action: "ping" });
 };
+
+/**
+ * Rejects any pending deferreds with an error. This is called when terminating the phantom instance
+ */
+ Phantom.prototype.rejectPendingDeferreds = function () {
+    Object.keys(this._pendingDeferreds).forEach(function (id) {
+        this._pendingDeferreds[id].reject(new Error("Phantomjs process exited"));
+    }, this);
+ }
 
 /**
  * Helper function that stringifies the given message-object, appends an end of line character

--- a/test/Phantom.test.js
+++ b/test/Phantom.test.js
@@ -311,6 +311,18 @@ describe("Phantom", function () {
                 });
             });
 
+            it("should reject with an error if phantomjs process is killed", function (done) {
+                phridge.spawn({ someConfig: true }).then(function (ph) {
+                    ph.run(function(resolve, reject) {
+                        resolve(true);
+                    }).catch(function (err) {
+                        expect(err.message).to.equal('Phantomjs process exited');
+                        done();
+                    });
+                    ph.childProcess.kill();
+                });
+            });
+
         });
 
         describe(".createPage()", function () {


### PR DESCRIPTION
Hi,

I'm trying to use this for https://github.com/Producters/express-crawler-snapshots. I need it to be fairly robust and handle phantomjs child process crashing or being killed.

I encountered and fixed two issues that pop up when a phantomjs process dies:

* ping timeout is never cleared. Callback tries to write to already closed stdin socket and crashes the process
* pending deffereds are not rejected, leaving the callers hanging