### PR TITLE
phantomjs-prebuilt

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -2,7 +2,7 @@
 
 var node = require("when/node");
 var childProcess = require("child_process");
-var phantomjs = require("phantomjs");
+var phantomjs = require("phantomjs-prebuilt");
 var config = require("./config.js");
 var when = require("when");
 var fs = require("fs");

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "fork-stream": "^0.0.4",
     "linerstream": "^0.1.4",
-    "phantomjs": "^2.1.2",
+    "phantomjs-prebuilt": "^2.1.3",
     "temp": "^0.8.0",
     "when": "^3.4.2"
   },


### PR DESCRIPTION
npm package "phantomjs" has now been deprecated,
and changed to "phantomjs-prebuilt"
https://github.com/Medium/phantomjs#phantomjs-prebuilt
https://github.com/Medium/phantomjs/pull/453

phantomjs-prebuilt now installs phantomjs 2.1.1 so it fixes #30 as well
