### PR TITLE
chore(deps): switch phantomjs-prebuilt to tilde

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "fork-stream": "^0.0.4",
     "linerstream": "^0.1.4",
-    "phantomjs-prebuilt": "^2.1.3",
+    "phantomjs-prebuilt": "~2.1.3",
     "temp": "^0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
PhantomJS tends to include fixes that may break rendering in minor versions. Using tilde is safer :-)

As a side note, perhaps phridge should be pinned/synced with PhantomJS releases?

ie.:

phridge 2.1.3 => `"phantomjs-prebuilt": "2.1.3"`
phridge 2.1.4 => `"phantomjs-prebuilt": "2.1.4"`

And so on.
